### PR TITLE
hotfix

### DIFF
--- a/P2PNet/DicoveryChannels/WAN/BootstrapChannel.cs
+++ b/P2PNet/DicoveryChannels/WAN/BootstrapChannel.cs
@@ -98,7 +98,7 @@ namespace P2PNet.DicoveryChannels.WAN
                 if (responsePacket != null)
                 {
                     string dataout = Encoding.UTF8.GetString(UnwrapData(responsePacket));
-                    if (this.BootstrapServer.Identifier == string.Empty) { this.BootstrapServer.Identifier = responsePacket.SourceOriginIdentifier; } // set identifier from response packet
+                    if (string.IsNullOrEmpty(this.BootstrapServer.Identifier)) { this.BootstrapServer.Identifier = responsePacket.SourceOriginIdentifier; } // set identifier from response packet
 
                     PeerNetwork.KnownPeers.Add(BootstrapServer);
                     InitialBootstrapHandler.Invoke(dataout);

--- a/P2PNet/PeerNetwork.cs
+++ b/P2PNet/PeerNetwork.cs
@@ -632,7 +632,7 @@ namespace P2PNet
             {
                 if (!KnownPeers.Contains(newpeer))
                 {
-                    if (newpeer.Protocol.IsDirectConnection == true)
+                    if (newpeer.Protocol?.IsDirectConnection ?? true)
                     {
                         AddPeer(newpeer);
                     }


### PR DESCRIPTION
* Improve null handling for peer protocol and identifier checks
* Updated BootstrapServer.Identifier assignment to use string.IsNullOrEmpty for better null/empty detection